### PR TITLE
fix: define server attribute

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -13,7 +13,7 @@ from vega_datasets import data as datasets
 
 app = dash.Dash(__name__)
 
-# server = app.server
+server = app.server
 
 # Load data
 gapminder = pd.read_csv(


### PR DESCRIPTION
Fixes the deployment bug on Heroku - `Failed to find attribute 'server' in 'src.app'`